### PR TITLE
Fix breakpoint downloading for OkHttpDownloader and downloader

### DIFF
--- a/library/src/main/java/com/coolerfall/download/DownloadManager.java
+++ b/library/src/main/java/com/coolerfall/download/DownloadManager.java
@@ -38,7 +38,7 @@ public final class DownloadManager {
 			return -1;
 		}
 
-		request.setDownloader(downloader);
+		request.setDownloader(downloader.copy());
 
 		/* add download request into download request queue */
 		return downloadRequestQueue.add(request) ? request.downloadId() : -1;

--- a/library/src/main/java/com/coolerfall/download/Downloader.java
+++ b/library/src/main/java/com/coolerfall/download/Downloader.java
@@ -41,4 +41,9 @@ public interface Downloader {
 	 * Close downloader and stop downloader.
 	 */
 	void close();
+
+	/**
+	 * Make a copy for this downloader.
+	 */
+	Downloader copy();
 }

--- a/library/src/main/java/com/coolerfall/download/OkHttpDownloader.java
+++ b/library/src/main/java/com/coolerfall/download/OkHttpDownloader.java
@@ -93,6 +93,7 @@ public final class OkHttpDownloader implements Downloader {
 		body = response.body();
 		switch (statusCode) {
 		case 200:
+		case 206:
 			return statusCode;
 
 		case 301:
@@ -107,9 +108,6 @@ public final class OkHttpDownloader implements Downloader {
 			} else {
 				throw new DownloadException(statusCode, response.message());
 			}
-
-		default:
-			body.close();
 		}
 
 		return statusCode;
@@ -127,6 +125,10 @@ public final class OkHttpDownloader implements Downloader {
 		if (body != null) {
 			body.close();
 		}
+	}
+
+	@Override public Downloader copy() {
+		return create(client);
 	}
 
 	/* read response content length from server */

--- a/library/src/main/java/com/coolerfall/download/URLDownloader.java
+++ b/library/src/main/java/com/coolerfall/download/URLDownloader.java
@@ -114,6 +114,10 @@ public final class URLDownloader implements Downloader {
 		}
 	}
 
+	@Override public Downloader copy() {
+		return create();
+	}
+
 	/* read response content length from server */
 	int getContentLength(HttpURLConnection conn) {
 		String transferEncoding = conn.getHeaderField(TRANSFER_ENCODING);


### PR DESCRIPTION
Fix breakpoint downloading for OkHttpDownloader, and add copy method in Downloader so we can get a new instance when create a new DownloadRequest.